### PR TITLE
NMS-13911: Please update the copyright year on the docs page!

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <p>Copyright (c) The OpenNMS Group, Inc.</p>
+  <p>Copyright (c)2002–{docyear} The OpenNMS Group, Inc.</p>
   <p>Licensed under the terms of the AGPL-3.0.</p>
-  <p> Legal Notice</p>
+  <p><a href="https://docs.opennms.com/start-page/1.0.0/index.html" target="_blank">Legal Notice</a></p>
 </footer>


### PR DESCRIPTION
NMS-13911: Please update the copyright year on the docs page! - updated the copyright date for the footer and added a hyperlink to the Legal Notice content.