### PR TITLE
Update to Antora 3.1.1 and search focus

### DIFF
--- a/src/css/search.css
+++ b/src/css/search.css
@@ -1,0 +1,121 @@
+.search-result-dropdown-menu {
+  position: absolute;
+  z-index: 100;
+  display: block;
+  right: 0;
+  left: inherit;
+  top: 100%;
+  border-radius: 4px;
+  margin: 6px 0 0;
+  padding: 0;
+  text-align: left;
+  height: auto;
+  background: transparent;
+  border: none;
+  max-width: 600px;
+  min-width: 500px;
+  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.2), 0 2px 3px 0 rgba(0, 0, 0, 0.1);
+}
+
+@media screen and (max-width: 768px) {
+  .search-result-dropdown-menu {
+    min-width: calc(100vw - 3.75rem);
+  }
+}
+
+.search-result-dataset {
+  position: relative;
+  border: 1px solid #d9d9d9;
+  background: #fff;
+  border-radius: 4px;
+  overflow: auto;
+  padding: 8px;
+  max-height: calc(100vh - 5.25rem);
+  line-height: 1.5;
+}
+
+.search-result-item {
+  display: flex;
+  margin-top: 0.5rem;
+}
+
+.search-result-component-header {
+  color: #1e1e1e;
+  border-bottom: 1px solid #ddd;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+  padding-top: 0.25em;
+  padding-bottom: 0.25em;
+}
+
+.search-result-document-title {
+  width: 33%;
+  border-right: 1px solid #ddd;
+  color: #02060c;
+  font-weight: 500;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.5rem 0.5rem 0;
+  text-align: right;
+  position: relative;
+  word-wrap: break-word;
+}
+
+.search-result-document-hit {
+  flex: 1;
+  font-size: 0.75rem;
+  color: #63676d;
+}
+
+.search-result-document-hit > a {
+  color: inherit;
+  display: block;
+  padding: 0.55rem 0.25rem 0.55rem 0.75rem;
+}
+
+.search-result-document-hit > a:hover {
+  background-color: rgba(69, 142, 225, 0.05);
+}
+
+.search-result-document-hit .search-result-highlight {
+  color: #174d8c;
+  background: rgba(143, 187, 237, 0.1);
+  padding: 0.1em 0.05em;
+  font-weight: 500;
+}
+
+.search-result-document-hit .search-result-section-title {
+  color: #303030;
+  font-weight: 500;
+  font-size: 1.05em;
+  margin-bottom: 0.25em;
+}
+
+#search-input {
+  padding: 0.25em;
+}
+
+#search-input:focus {
+  outline: none;
+}
+
+#search-field {
+  display: flex;
+}
+
+#search-field .filter {
+  border-left: none;
+  border-radius: 0 0.1em 0.1em 0;
+  color: #5d5d5d;
+  cursor: pointer;
+  font-size: 0.875em;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+#search-field.has-filter > input {
+  border-right: none;
+  border-radius: 0.1em 0 0 0.1em;
+}

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -2,9 +2,11 @@
 @import "typeface-roboto-mono.css";
 @import "vars.css";
 @import "base.css";
+@import "search.css";
 @import "body.css";
 @import "nav.css";
 @import "main.css";
+@import "admonition-labels.css";
 @import "toolbar.css";
 @import "breadcrumbs.css";
 @import "page-versions.css";

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -1,7 +1,7 @@
 <script src="{{{uiRootPath}}}/js/site.js"></script>
 <script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
 {{#if env.SITE_SEARCH_PROVIDER}}
-{{> search-scripts}}
+  {{> search-scripts}}
 {{/if}}
 <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js"></script>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -12,8 +12,13 @@
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
         {{#if env.DOCSEARCH_ENABLED}}
-          <div class="navbar-item">
-            <input id="search-input" type="text" placeholder="Search docs">
+          <div class="navbar-item search hide-for-print">
+            <div id="search-field" class="field has-filter">
+              <input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+              <label class="filter checkbox">
+                <input type="checkbox" data-facet-filter="component:{{page.component.name}}" checked> In this project
+              </label>
+            </div>
           </div>
         {{/if}}
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
Added the functionality to limit the search for currently selected components by default. I have updated antora-lunr search extension to the latest version.

## Reviewers hint

The antora-lunr extension has refactored the search.js and we have forked the search.js with changes for our search highlighting. The search highlight doesn't work anymore and can't easily be backported. To make this a sustainable solution we should provide the search highlighting upstream to the [antora-lunr extension](https://gitlab.com/antora/antora-lunr-extension). The issue is documented in https://issues.opennms.org/browse/NMS-13540 and can't be addressed in this PR.

## Risk

When we merge this PR into master we can make a new release for our Antora OpenNMS UI. We can decide freely where to use this version, e.g. docs.opennms.com or cloud docs. If something breaks we can roll back to an older release easily.