### PR TITLE
NMS-15531: Docs lower footer needs copyright year bump

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <p>Copyright (c) 2002–2023 The OpenNMS Group, Inc.</p>
+  <p>Copyright (c) 2015–2023 The OpenNMS Group, Inc.</p>
   <p>Licensed under the terms of the AGPL-3.0.</p>
   <p><a href="https://docs.opennms.com/start-page/1.0.0/index.html" target="_blank">Legal Notice</a></p>
 </footer>


### PR DESCRIPTION
Updated copyright in footer to be consistent with how copyright appears elsewhere in the docs. (2015-2023). Still unsure why variable date does not work in the footer.