### PR TITLE
NMS-17865: Remove polyfill reference

### DIFF
--- a/release.version
+++ b/release.version
@@ -1,2 +1,2 @@
-release="3.1.0"
-codename="Antora UI 3.1.0 (The Secret of Monkey Island)"
+release="3.1.1"
+codename="Antora UI 3.1.1 (The Secret of Monkey Island 2)"

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -3,7 +3,6 @@
 {{#if env.SITE_SEARCH_PROVIDER}}
   {{> search-scripts}}
 {{/if}}
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js"></script>
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({


### PR DESCRIPTION
Remove reference to the `polyfill.js` library. This library is both no longer needed as well as it has been compromised and being used to inject malware.

More info here: https://news.ycombinator.com/item?id=40791829