### PR TITLE
Fix the copyright date in the footer

### DIFF
--- a/release.version
+++ b/release.version
@@ -1,2 +1,2 @@
-release="3.1.1"
-codename="Antora UI 3.1.1 (The Secret of Monkey Island 2)"
+release="3.1.2"
+codename="Antora UI 3.1.2 (The Curse of Monkey Island)"

--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <p>Copyright (c) 2015–2023 The OpenNMS Group, Inc.</p>
+  <p>Copyright (c) 2015–2025 The OpenNMS Group, Inc.</p>
   <p>Licensed under the terms of the AGPL-3.0.</p>
   <p><a href="https://docs.opennms.com/start-page/1.0.0/index.html" target="_blank">Legal Notice</a></p>
 </footer>


### PR DESCRIPTION
Updated `footer-content.hbs` earlier, preparing the files for release; 

We want to make sure the correct copyright date is shown.